### PR TITLE
fix: dowload from miror before source

### DIFF
--- a/etl/src/providers/FileManager.spec.ts
+++ b/etl/src/providers/FileManager.spec.ts
@@ -75,9 +75,13 @@ test.serial('should download mirrored ressource url if not on fs', async (t) => 
   const filepath = await t.context.fileManager.download(t.context.RESSOURCE_URL);
 
   // Assert
-  sinon.assert.calledOnceWithExactly(t.context.axiosStub, `${t.context.fileManager.mirrorUrl}/${hash(t.context.RESSOURCE_URL)}`, {
-    responseType: 'stream',
-  });
+  sinon.assert.calledOnceWithExactly(
+    t.context.axiosStub,
+    `${t.context.fileManager.mirrorUrl}/${hash(t.context.RESSOURCE_URL)}`,
+    {
+      responseType: 'stream',
+    },
+  );
   t.deepEqual(readFileSync(filepath, 'utf8'), FILE_CONTENT_STRING);
 });
 
@@ -95,7 +99,7 @@ test.serial('shoud fallback to source if no mirror', async (t) => {
   // Assert
   sinon.assert.calledOnceWithExactly(t.context.axiosStub, t.context.RESSOURCE_URL, { responseType: 'stream' });
   t.deepEqual(readFileSync(filepath, 'utf8'), FILE_CONTENT_STRING);
-})
+});
 
 test.serial('should fallback to source if any error code with mirrored ressource', async (t) => {
   // Arrange
@@ -109,14 +113,14 @@ test.serial('should fallback to source if any error code with mirrored ressource
 
   // Assert
   sinon.assert.calledTwice(t.context.axiosStub);
-  t.true(t.context.axiosStub.getCall(0).calledWithExactly(`${t.context.fileManager.mirrorUrl}/${hash(t.context.RESSOURCE_URL)}`, {
-    responseType: 'stream',
-  }));
   t.true(
     t.context.axiosStub
-      .getCall(1)
-      .calledWithExactly(t.context.RESSOURCE_URL, { responseType: 'stream' }),
+      .getCall(0)
+      .calledWithExactly(`${t.context.fileManager.mirrorUrl}/${hash(t.context.RESSOURCE_URL)}`, {
+        responseType: 'stream',
+      }),
   );
+  t.true(t.context.axiosStub.getCall(1).calledWithExactly(t.context.RESSOURCE_URL, { responseType: 'stream' }));
 
   t.deepEqual(readFileSync(filepath, 'utf8'), FILE_CONTENT_STRING);
 });

--- a/etl/src/providers/FileManager.ts
+++ b/etl/src/providers/FileManager.ts
@@ -5,8 +5,13 @@ import { basename, join } from 'path';
 import { Readable } from 'stream';
 import {
   getAllFiles,
-  getFileExtensions, hash,
-  randomString, un7zFile, ungzFile, unzipFile, writeFile
+  getFileExtensions,
+  hash,
+  randomString,
+  un7zFile,
+  ungzFile,
+  unzipFile,
+  writeFile,
 } from '../helpers';
 
 import { ArchiveFileTypeEnum, FileManagerConfigInterface, FileManagerInterface, FileTypeEnum } from '../interfaces';
@@ -98,8 +103,8 @@ export class FileManager implements FileManagerInterface {
       // If file not found, download it on miror
       try {
         const mirrorUrl = this.getMirrorUrl(url);
-        if(!mirrorUrl) {
-          throw e
+        if (!mirrorUrl) {
+          throw e;
         }
         await this.dowloadMiror(mirrorUrl, filepath);
       } catch (e) {

--- a/etl/src/providers/FileManager.ts
+++ b/etl/src/providers/FileManager.ts
@@ -1,20 +1,15 @@
-import axios, { AxiosError } from 'axios';
+import axios from 'axios';
 import { access, mkdir } from 'fs/promises';
-import { Readable } from 'stream';
 import mapshaper from 'mapshaper';
 import { basename, join } from 'path';
+import { Readable } from 'stream';
 import {
-  writeFile,
-  hash,
-  randomString,
-  unzipFile,
-  ungzFile,
-  un7zFile,
   getAllFiles,
-  getFileExtensions,
+  getFileExtensions, hash,
+  randomString, un7zFile, ungzFile, unzipFile, writeFile
 } from '../helpers';
 
-import { FileManagerInterface, FileManagerConfigInterface, ArchiveFileTypeEnum, FileTypeEnum } from '../interfaces';
+import { ArchiveFileTypeEnum, FileManagerConfigInterface, FileManagerInterface, FileTypeEnum } from '../interfaces';
 
 export class FileManager implements FileManagerInterface {
   readonly basePath: string;


### PR DESCRIPTION
Objectif : utiliser notre miroir pour 
- que le téléchargement des fichiers soient plus rapides
- qu'il n'y ait aucun risque d'altération des fichiers par les tiers