### PR TITLE
Suppression des `console.debug` de requêtes SQL

### DIFF
--- a/etl/src/common/AbstractDatafunction.ts
+++ b/etl/src/common/AbstractDatafunction.ts
@@ -53,7 +53,6 @@ export abstract class AbstractDatafunction implements DatasetInterface {
 
   async load(): Promise<void> {
     try {
-      console.debug(this.sql);
       await this.connection.query(this.sql);
     } catch (e) {
       throw new SqlError(this, (e as Error).message);

--- a/etl/src/common/AbstractDataset.ts
+++ b/etl/src/common/AbstractDataset.ts
@@ -87,7 +87,6 @@ export abstract class AbstractDataset implements DatasetInterface {
         : this.beforeSqlPath
         ? await loadFileAsString(this.beforeSqlPath)
         : generatedSql;
-      console.debug(sql);
       await this.connection.query(sql);
     } catch (e) {
       throw new SqlError(this, (e as Error).message);

--- a/etl/src/common/AbstractDatastructure.ts
+++ b/etl/src/common/AbstractDatastructure.ts
@@ -40,7 +40,6 @@ export abstract class AbstractDatastructure implements DatasetInterface {
 
   async before(): Promise<void> {
     try {
-      console.debug(this.sql);
       await this.connection.query(this.sql);
     } catch (e) {
       throw new SqlError(this, (e as Error).message);

--- a/etl/src/common/AbstractDatatreatment.ts
+++ b/etl/src/common/AbstractDatatreatment.ts
@@ -57,7 +57,6 @@ export abstract class AbstractDatatreatment implements DatasetInterface {
 
   async after(): Promise<void> {
     try {
-      console.debug(this.sql);
       await this.connection.query(this.sql);
     } catch (e) {
       throw new SqlError(this, (e as Error).message);


### PR DESCRIPTION
Ça pollue les logs et ça n'est pas très utile.